### PR TITLE
Add width to button and TextInput

### DIFF
--- a/addon/components/ui-button/component.ts
+++ b/addon/components/ui-button/component.ts
@@ -18,7 +18,7 @@ export default class UiButton extends Component {
   onClick?: Function | null = null;
   label?: string = "";
   appearance?: "default" | "strong" | "minimal" = "default";
-  width?: string; //Accepts any standard CSS width value
+  width?: string = ""; //Accepts any standard CSS width value
   intent?: "none" | "success" | "warning" | "danger" = "none";
   size?: "default" | "small" | "large" = "default";
   isDisabled?: boolean = false;

--- a/addon/components/ui-button/component.ts
+++ b/addon/components/ui-button/component.ts
@@ -15,9 +15,10 @@ export default class UiButton extends Component {
 
   onClick?: Function | null = null;
   label?: string = "";
-  appearance?: string = "default"; //Enum: default, strong, minimal
-  intent?: string = "none"; //Enum: none, success, warning, danger
-  size?: string = "default"; //Enum: small, large
+  appearance?: "default" | "strong" | "minimal" = "default";
+  width?: "full" | "";
+  intent?: "none" | "success" | "warning" | "danger" = "none";
+  size?: "default" | "small" | "large" = "default";
   isDisabled?: boolean = false;
 
   @attribute()
@@ -25,6 +26,12 @@ export default class UiButton extends Component {
 
   @localClassName()
   isLoading?: boolean = false;
+
+  @localClassName()
+  @computed("width")
+  get widthClass(): string {
+    return `${this.width}-width`;
+  }
 
   @localClassName()
   @computed("appearance")

--- a/addon/components/ui-button/component.ts
+++ b/addon/components/ui-button/component.ts
@@ -6,6 +6,8 @@ import { tagName, attribute, classNames } from "@ember-decorators/component";
 import { or } from "@ember/object/computed";
 import { computed } from "@ember/object";
 import { isNone } from "@ember/utils";
+import { htmlSafe } from "@ember/string";
+import { SafeString } from "handlebars";
 
 @classNames("ui-button")
 @localClassNames("ui-button")
@@ -29,8 +31,8 @@ export default class UiButton extends Component {
 
   @attribute()
   @computed("width")
-  get style(): string {
-    return `width:${this.width}`;
+  get style(): SafeString {
+    return htmlSafe(`width:${this.width}`);
   }
 
   @localClassName()

--- a/addon/components/ui-button/component.ts
+++ b/addon/components/ui-button/component.ts
@@ -16,7 +16,7 @@ export default class UiButton extends Component {
   onClick?: Function | null = null;
   label?: string = "";
   appearance?: "default" | "strong" | "minimal" = "default";
-  width?: "full" | "default" = "default";
+  width?: string; //Accepts any standard CSS width measurement
   intent?: "none" | "success" | "warning" | "danger" = "none";
   size?: "default" | "small" | "large" = "default";
   isDisabled?: boolean = false;
@@ -27,10 +27,10 @@ export default class UiButton extends Component {
   @localClassName()
   isLoading?: boolean = false;
 
-  @localClassName()
+  @attribute()
   @computed("width")
-  get widthClass(): string {
-    return `${this.width}-width`;
+  get style(): string {
+    return `width:${this.width}`;
   }
 
   @localClassName()

--- a/addon/components/ui-button/component.ts
+++ b/addon/components/ui-button/component.ts
@@ -18,7 +18,7 @@ export default class UiButton extends Component {
   onClick?: Function | null = null;
   label?: string = "";
   appearance?: "default" | "strong" | "minimal" = "default";
-  width?: string; //Accepts any standard CSS width measurement
+  width?: string; //Accepts any standard CSS width value
   intent?: "none" | "success" | "warning" | "danger" = "none";
   size?: "default" | "small" | "large" = "default";
   isDisabled?: boolean = false;
@@ -33,7 +33,7 @@ export default class UiButton extends Component {
   @computed("width")
   get style(): SafeString {
     if (this.width) {
-      return htmlSafe(`width:${this.width}`);
+      return htmlSafe(`width: ${this.width}`);
     } else {
       return htmlSafe("");
     }

--- a/addon/components/ui-button/component.ts
+++ b/addon/components/ui-button/component.ts
@@ -32,7 +32,11 @@ export default class UiButton extends Component {
   @attribute()
   @computed("width")
   get style(): SafeString {
-    return htmlSafe(`width:${this.width}`);
+    if (this.width) {
+      return htmlSafe(`width:${this.width}`);
+    } else {
+      return htmlSafe("");
+    }
   }
 
   @localClassName()

--- a/addon/components/ui-button/component.ts
+++ b/addon/components/ui-button/component.ts
@@ -16,7 +16,7 @@ export default class UiButton extends Component {
   onClick?: Function | null = null;
   label?: string = "";
   appearance?: "default" | "strong" | "minimal" = "default";
-  width?: "full" | "";
+  width?: "full" | "default" = "default";
   intent?: "none" | "success" | "warning" | "danger" = "none";
   size?: "default" | "small" | "large" = "default";
   isDisabled?: boolean = false;

--- a/addon/components/ui-button/styles.css
+++ b/addon/components/ui-button/styles.css
@@ -201,3 +201,7 @@
   border-color: neutral-n4;
   color: neutral-n5;
 }
+
+.ui-button.full-width {
+  width: 100%;
+}

--- a/addon/components/ui-button/styles.css
+++ b/addon/components/ui-button/styles.css
@@ -201,7 +201,3 @@
   border-color: neutral-n4;
   color: neutral-n5;
 }
-
-.ui-button.full-width {
-  width: 100%;
-}

--- a/addon/components/ui-button/template.hbs
+++ b/addon/components/ui-button/template.hbs
@@ -3,7 +3,7 @@
 {{/if}}
 <span local-class="label">
   {{#if this.label}}
-    {{label}}
+    {{this.label}}
   {{else}}
     {{yield}}
   {{/if}}

--- a/addon/components/ui-text-input/component.ts
+++ b/addon/components/ui-text-input/component.ts
@@ -38,6 +38,12 @@ export default class UiTextInput extends Component {
     }
   }
 
+  @localClassName()
+  @computed("width")
+  get hasWidth(): boolean {
+    return !!this.width;
+  }
+
   @action
   onKeyUp(value: string) {
     if (isNone(this.onSetValue)) {

--- a/addon/components/ui-text-input/component.ts
+++ b/addon/components/ui-text-input/component.ts
@@ -2,10 +2,12 @@ import Component from "@ember/component";
 // @ts-ignore: Ignore import of compiled template
 import template from "./template";
 import { localClassNames, localClassName } from "ember-css-modules";
-import { classNames } from "@ember-decorators/component";
+import { classNames, attribute } from "@ember-decorators/component";
 import { action } from "@ember/object";
 import { isNone } from "@ember/utils";
 import { set, computed } from "@ember/object";
+import { htmlSafe } from "@ember/string";
+import { SafeString } from "handlebars";
 
 @classNames("ui-text-input")
 @localClassNames("ui-text-input")
@@ -21,15 +23,15 @@ export default class UiTextInput extends Component {
   disabled?: boolean = false;
   max?: number | null = null;
   min?: number | null = null;
-  width?: "full" | "default" = "default";
+  width?: string; //Accepts any standard CSS width measurement
 
   @localClassName()
   hasError?: boolean = false;
 
-  @localClassName()
+  @attribute()
   @computed("width")
-  get widthClass(): string {
-    return `${this.width}-width`;
+  get style(): SafeString {
+    return htmlSafe(`width:${this.width}`);
   }
 
   @action

--- a/addon/components/ui-text-input/component.ts
+++ b/addon/components/ui-text-input/component.ts
@@ -5,7 +5,7 @@ import { localClassNames, localClassName } from "ember-css-modules";
 import { classNames } from "@ember-decorators/component";
 import { action } from "@ember/object";
 import { isNone } from "@ember/utils";
-import { set } from "@ember/object";
+import { set, computed } from "@ember/object";
 
 @classNames("ui-text-input")
 @localClassNames("ui-text-input")
@@ -21,9 +21,16 @@ export default class UiTextInput extends Component {
   disabled?: boolean = false;
   max?: number | null = null;
   min?: number | null = null;
+  width?: "full" | "default" = "default";
 
   @localClassName()
   hasError?: boolean = false;
+
+  @localClassName()
+  @computed("width")
+  get widthClass(): string {
+    return `${this.width}-width`;
+  }
 
   @action
   onKeyUp(value: string) {

--- a/addon/components/ui-text-input/component.ts
+++ b/addon/components/ui-text-input/component.ts
@@ -23,7 +23,7 @@ export default class UiTextInput extends Component {
   disabled?: boolean = false;
   max?: number | null = null;
   min?: number | null = null;
-  width?: string; //Accepts any standard CSS width measurement
+  width?: string; //Accepts any standard CSS width value
 
   @localClassName()
   hasError?: boolean = false;
@@ -32,16 +32,10 @@ export default class UiTextInput extends Component {
   @computed("width")
   get style(): SafeString {
     if (this.width) {
-      return htmlSafe(`width:${this.width}`);
+      return htmlSafe(`width: ${this.width}`);
     } else {
       return htmlSafe("");
     }
-  }
-
-  @localClassName()
-  @computed("width")
-  get hasWidth(): boolean {
-    return !!this.width;
   }
 
   @action

--- a/addon/components/ui-text-input/component.ts
+++ b/addon/components/ui-text-input/component.ts
@@ -31,7 +31,11 @@ export default class UiTextInput extends Component {
   @attribute()
   @computed("width")
   get style(): SafeString {
-    return htmlSafe(`width:${this.width}`);
+    if (this.width) {
+      return htmlSafe(`width:${this.width}`);
+    } else {
+      return htmlSafe("");
+    }
   }
 
   @action

--- a/addon/components/ui-text-input/component.ts
+++ b/addon/components/ui-text-input/component.ts
@@ -23,7 +23,7 @@ export default class UiTextInput extends Component {
   disabled?: boolean = false;
   max?: number | null = null;
   min?: number | null = null;
-  width?: string; //Accepts any standard CSS width value
+  width?: string = ""; //Accepts any standard CSS width value
 
   @localClassName()
   hasError?: boolean = false;

--- a/addon/components/ui-text-input/styles.css
+++ b/addon/components/ui-text-input/styles.css
@@ -28,6 +28,6 @@
   cursor: not-allowed;
 }
 
-.ui-text-input.has-width input {
+.ui-text-input :global(.has-width) {
   width: 100%;
 }

--- a/addon/components/ui-text-input/styles.css
+++ b/addon/components/ui-text-input/styles.css
@@ -27,3 +27,7 @@
   background: neutral-n2;
   cursor: not-allowed;
 }
+
+.ui-text-input.full-width input {
+  width: 100%;
+}

--- a/addon/components/ui-text-input/styles.css
+++ b/addon/components/ui-text-input/styles.css
@@ -28,6 +28,6 @@
   cursor: not-allowed;
 }
 
-.ui-text-input input {
+.ui-text-input.has-width input {
   width: 100%;
 }

--- a/addon/components/ui-text-input/styles.css
+++ b/addon/components/ui-text-input/styles.css
@@ -28,6 +28,6 @@
   cursor: not-allowed;
 }
 
-.ui-text-input.full-width input {
+.ui-text-input input {
   width: 100%;
 }

--- a/addon/components/ui-text-input/template.hbs
+++ b/addon/components/ui-text-input/template.hbs
@@ -1,4 +1,5 @@
 {{input
+  class=(if (not (is-empty this.width)) "has-width")
   id=@inputId
   value=@value
   required=@required


### PR DESCRIPTION
The purpose of this PR is to allow the user to set the width (mainly full-width) of a button and/or text-input without the need to do it locally in their CSS.

After PR:
`@width="full"` can be passed in to the UiButton and UiTextInput components, if none is specific, the width will not be changed.